### PR TITLE
fix: Correct return value handling in web app

### DIFF
--- a/js_deobfuscator/src/web_app.py
+++ b/js_deobfuscator/src/web_app.py
@@ -14,10 +14,8 @@ def index():
     if request.method == 'POST':
         obfuscated_code = request.form.get('obfuscated_code', '')
         if obfuscated_code:
-            # The deobfuscate function returns the code and a report dictionary.
-            # For the web UI, we'll just show the code.
-            clean_code, _ = deobfuscate(obfuscated_code)
-            deobfuscated_code = clean_code
+            # The deobfuscate function now returns only the deobfuscated code.
+            deobfuscated_code = deobfuscate(obfuscated_code)
 
     return render_template('index.html', obfuscated_code=obfuscated_code, deobfuscated_code=deobfuscated_code)
 


### PR DESCRIPTION
This commit fixes a `ValueError` in `web_app.py`.

The `deobfuscate` function was updated to return a single value, but the web app was still trying to unpack two values. This change corrects the assignment to handle the single return value, making the web application functional.