### PR TITLE
Fix javascript bug and improve deobfuscator

### DIFF
--- a/deobfuscated_output.js
+++ b/deobfuscated_output.js
@@ -1,4 +1,39 @@
 var xMDtMYu, Nq4HDa, ge8Bw95, n5tQfMg, MCPbWc, n7KNjev, jOnQnP, CRGL7W, hWWgOZ;
+
+function wMCBOR() {
+    wMCBOR = function() {};
+}
+
+function NLUN2gP(xMDtMYu) {
+    var Nq4HDa = 'Y"/D}.:]7%[)>Nh*<+@5L~z;^_OB=I?igje`x{m|(a$clS8A&b!Kk,no9C6MptGqEdFsJZuRf#Q4T3r1P2XHWVUwvy0',
+        ge8Bw95, n5tQfMg, MCPbWc, n7KNjev, jOnQnP, CRGL7W, hWWgOZ;
+    wMCBOR(ge8Bw95 = '' + (xMDtMYu || ''), n5tQfMg = ge8Bw95.length, MCPbWc = [], n7KNjev = 0, jOnQnP = 0, CRGL7W = -1);
+    for (hWWgOZ = 0; hWWgOZ < n5tQfMg; hWWgOZ++) {
+        var NLUN2gP = Nq4HDa.indexOf(ge8Bw95[hWWgOZ]);
+        if (NLUN2gP === -1)
+            continue;
+        if (CRGL7W < 0) {
+            CRGL7W = NLUN2gP;
+        } else {
+            wMCBOR(CRGL7W += NLUN2gP * 91, n7KNjev |= CRGL7W << jOnQnP, jOnQnP += (CRGL7W & 8191) > 88 ? 13 : 14);
+            do {
+                wMCBOR(MCPbWc.push(n7KNjev & 255), n7KNjev >>= 8, jOnQnP -= 8);
+            } while (jOnQnP > 7);
+            CRGL7W = -1;
+        }
+    }
+    if (CRGL7W > -1) {
+        MCPbWc.push((n7KNjev | CRGL7W << jOnQnP) & 255);
+    }
+    return FTckNi(MCPbWc);
+}
+
+function bcn4zHD(ge8Bw95) {
+    if (typeof xMDtMYu[ge8Bw95] === 'undefined') {
+        return xMDtMYu[ge8Bw95] = NLUN2gP(Nq4HDa[ge8Bw95]);
+    }
+    return xMDtMYu[ge8Bw95];
+}
 wMCBOR(xMDtMYu = {}, Nq4HDa = [
     '[I#n8t%Ny6]<nt5BYn:]PmT8N@j',
     'sD3!wSq`)MP9${N|V|>Q/&E^}',
@@ -126,6 +161,39 @@ wMCBOR(xMDtMYu = {}, Nq4HDa = [
     '`$G:',
     '+(sgaP!?$LdI?tL('
 ]);
+
+function DXS_zGs() {
+    var xMDtMYu = [
+            function() {
+                return globalThis;
+            },
+            function() {
+                return global;
+            },
+            function() {
+                return window;
+            },
+            function() {
+                return new Function('return this')();
+            }
+        ],
+        Nq4HDa, ge8Bw95, n5tQfMg;
+    wMCBOR(Nq4HDa = null, ge8Bw95 = []);
+    try {
+        wMCBOR(Nq4HDa = Object, ge8Bw95.push(''.__proto__.constructor.name));
+    } catch (MCPbWc) {}
+    ZBj5Hd:
+        for (n5tQfMg = 0; n5tQfMg < xMDtMYu.length; n5tQfMg++)
+            try {
+                var n7KNjev;
+                Nq4HDa = xMDtMYu[n5tQfMg]();
+                for (n7KNjev = 0; n7KNjev < ge8Bw95.length; n7KNjev++)
+                    if (typeof Nq4HDa[ge8Bw95[n7KNjev]] === 'undefined')
+                        continue ZBj5Hd;
+                return Nq4HDa;
+            } catch (MCPbWc) {}
+    return Nq4HDa || this;
+}
 wMCBOR(ge8Bw95 = DXS_zGs() || {}, n5tQfMg = ge8Bw95.TextDecoder, MCPbWc = ge8Bw95.Uint8Array, n7KNjev = ge8Bw95.Buffer, jOnQnP = ge8Bw95.String || String, CRGL7W = ge8Bw95.Array || Array, hWWgOZ = function() {
     var xMDtMYu = new CRGL7W(128),
         Nq4HDa, ge8Bw95;
@@ -139,4 +207,46 @@ wMCBOR(ge8Bw95 = DXS_zGs() || {}, n5tQfMg = ge8Bw95.TextDecoder, MCPbWc = ge8Bw9
         return ge8Bw95.join('');
     };
 }());
+
+function FTckNi(xMDtMYu) {
+    return typeof n5tQfMg !== 'undefined' && n5tQfMg ? new n5tQfMg().decode(new MCPbWc(xMDtMYu)) : typeof n7KNjev !== 'undefined' && n7KNjev ? n7KNjev.from(xMDtMYu).toString('utf-8') : hWWgOZ(xMDtMYu);
+}
+
+function zySdIz(ge8Bw95, n5tQfMg, MCPbWc, n7KNjev) {
+    if (!MCPbWc) {
+        MCPbWc = function(ge8Bw95) {
+            if (typeof xMDtMYu[ge8Bw95] === 'undefined') {
+                return xMDtMYu[ge8Bw95] = n5tQfMg(Nq4HDa[ge8Bw95]);
+            }
+            return xMDtMYu[ge8Bw95];
+        };
+    }
+    if (!n5tQfMg) {
+        n5tQfMg = function(ge8Bw95) {
+            var n5tQfMg = 'KEFH.CA}G:BD/N~%";=[<O]MJPI*L@|R_&Q`^{Z?Sb>$(Y)+,TUadcfVeWXxmwyz0k1239nl8#g!6ijh57q4orptsuv',
+                MCPbWc, n7KNjev, xMDtMYu, Nq4HDa, jOnQnP, CRGL7W, hWWgOZ;
+            wMCBOR(MCPbWc = '' + (ge8Bw95 || ''), n7KNjev = MCPbWc.length, xMDtMYu = [], Nq4HDa = 0, jOnQnP = 0, CRGL7W = -1);
+            for (hWWgOZ = 0; hWWgOZ < n7KNjev; hWWgOZ++) {
+                var NLUN2gP = n5tQfMg.indexOf(MCPbWc[hWWgOZ]);
+                if (NLUN2gP === -1)
+                    continue;
+                if (CRGL7W < 0) {
+                    CRGL7W = NLUN2gP;
+                } else {
+                    wMCBOR(CRGL7W += NLUN2gP * 91, Nq4HDa |= CRGL7W << jOnQnP, jOnQnP += (CRGL7W & 8191) > 88 ? 13 : 14);
+                    do {
+                        wMCBOR(xMDtMYu.push(Nq4HDa & 255), Nq4HDa >>= 8, jOnQnP -= 8);
+                    } while (jOnQnP > 7);
+                    CRGL7W = -1;
+                }
+            }
+            if (CRGL7W > -1) {
+                xMDtMYu.push((Nq4HDa | CRGL7W << jOnQnP) & 255);
+            }
+            return FTckNi(xMDtMYu);
+        };
+    }
+    wMCBOR(n7KNjev = MCPbWc(122) + ge8Bw95 + '!', console[MCPbWc(123)](n7KNjev));
+}
+
 zySdIz('Internet User');


### PR DESCRIPTION
This commit addresses a `ReferenceError` in an obfuscated javascript file.

The fix involved two main parts:
1.  Improving the python deobfuscator (`js_deobfuscator/src/deobfuscator.py`):
    -   The `FinalCleanup` pass was modified to no longer remove all function declarations, which was the cause of the original `ReferenceError`.
    -   The `ContextualResolver` pass was improved to be less aggressive. It now avoids resolving function calls that are nested inside other function declarations, which prevents it from breaking complex, nested decoder functions.
2.  Fixing the javascript file (`deobfuscated_output.js`):
    -   The improved deobfuscator was used to generate a clean, runnable version of the code.
    -   The `wMCBOR` function was moved to the top of the file to prevent any potential hoisting issues and make the code more robust.

The final deobfuscated and fixed javascript now runs correctly and produces the expected output.